### PR TITLE
Only list top level packages in depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,8 @@ Rules-Requires-Root: binary-targets
 
 Package: asl3
 Architecture: all
-Depends: ${misc:Depends}, asl3-asterisk, dahdi-linux, asl3-menu
-Suggests: allmon3, asl3-update-nodelist, asl3-asterisk-doc
+Depends: ${misc:Depends}, asl3-asterisk, asl3-menu
+Suggests: allmon3, asl3-update-nodelist
 Description: AllStarLink 3
  AllStarLink’s app_rpt version 3 (ASL3) is the
  next generation of repeater control software.


### PR DESCRIPTION
Dependencies of dependencies should not be explicitly listed in the top level package depends.