### PR TITLE
All PolicyKit Rules for the asterisk User

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ RELPLAT ?= deb$(shell lsb_release -rs 2> /dev/null)
 BUILDABLES = \
 	bin \
 	keys \
+	polkit \
 	share
 
 ifdef ${DESTDIR}

--- a/polkit/50-asl3.rules
+++ b/polkit/50-asl3.rules
@@ -1,0 +1,24 @@
+// Permit asterisk user to manage asterisk.service and allmon3.service
+polkit.addRule(function(action, subject) {
+    if ( action.id == "org.freedesktop.systemd1.manage-units" &&
+			subject.user == "asterisk" && (
+   		     	action.lookup("unit") == "asterisk.service" ||
+				action.lookup("unit") == "allmon3.service")
+		)
+ 		{ return polkit.Result.YES; }
+});
+
+// Permit asterisk user to shutdown and reboot
+polkit.addRule(function(action, subject) {
+    if ( subject.user == "asterisk" && 
+			(
+			action.id == "org.freedesktop.login1.reboot" ||
+			 action.id == "org.freedesktop.login1.reboot-ignore-inhibit" ||
+			 action.id == "org.freedesktop.login1.reboot-multiple-sessions" ||
+			 action.id == "org.freedesktop.login1.power-off" ||
+			 action.id == "org.freedesktop.login1.power-off-multiple-sessions" ||
+			 action.id == "org.freedesktop.login1.power-off-ignore-inhibit"
+			)
+        )
+        { return polkit.Result.YES; }
+});

--- a/polkit/Makefile
+++ b/polkit/Makefile
@@ -1,0 +1,30 @@
+sysconfdir      ?= /etc
+polkitdir    	?= $(sysconfdir)/polkit-1/rules.d
+astsrcdir		?= $(sysconfdir)/asterisk/scripts
+
+POLKIT_RULES = \
+	50-asl3.rules
+POLKIT_INSTALLABLES = $(patsubst %, $(DESTDIR)$(polkitdir)/%, $(POLKIT_RULES))
+
+AST_SCRIPTS = \
+	allmon3-restart \
+	allmon3-stop \
+	asterisk-restart \
+	asterisk-stop
+AST_SCRIPTS_INSTALLABLES = $(patsubst %, $(DESTDIR)$(astsrcdir)/%, $(AST_SCRIPTS))
+
+INSTALLABLES = $(POLKIT_INSTALLABLES) $(AST_SCRIPTS_INSTALLABLES)
+
+.PHONY: install
+install:    $(INSTALLABLES)
+
+
+$(DESTDIR)$(polkitdir)/%:	%
+	install -D -m 0644 $< $@
+
+$(DESTDIR)$(astsrcdir)/%:	%
+	install -D -m 0755 $< $@
+
+
+
+

--- a/polkit/Makefile
+++ b/polkit/Makefile
@@ -1,6 +1,5 @@
-sysconfdir      ?= /etc
-polkitdir    	?= $(sysconfdir)/polkit-1/rules.d
-astsrcdir		?= $(sysconfdir)/asterisk/scripts
+polkitdir    	?= /usr/share/polkit-1/rules.d
+astsrcdir		?= /etc/asterisk/scripts
 
 POLKIT_RULES = \
 	50-asl3.rules

--- a/polkit/allmon3-restart
+++ b/polkit/allmon3-restart
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+exec systemctl restart allmon3

--- a/polkit/allmon3-start
+++ b/polkit/allmon3-start
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+exec systemctl start allmon3

--- a/polkit/allmon3-stop
+++ b/polkit/allmon3-stop
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+exec systemctl stop allmon3

--- a/polkit/asterisk-restart
+++ b/polkit/asterisk-restart
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+exec systemctl restart asterisk

--- a/polkit/asterisk-start
+++ b/polkit/asterisk-start
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+exec systemctl start asterisk

--- a/polkit/asterisk-stop
+++ b/polkit/asterisk-stop
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+exec systemctl stop asterisk


### PR DESCRIPTION
This is a PolicyKit ruleset to permit the asterisk user to execute a limited number of actions
without the need for sudo or prompting for a password. Those are:

* `systemctl stop asterisk`
* `systemctl restart asterisk`
* `systemctl stop allmon3`
* `systemctl restart asterisk`
* `/usr/sbin/poweroff`
* `/usr/sbin/reboot`

Using a combination of wrapper scripts and appropriate function
configuration, Asterisk can restart itself, Allmon3, shutdown the system,
or reboot the system. Use of the wrapper scripts for `systemctl`
commands is essential for a clean execution of the scripts under the
polkit rules. The provided wrappers are:

* `/etc/asterisk/scripts/allmon3-restart`
* `/etc/asterisk/scripts/allmon3-stop`
* `/etc/asterisk/scripts/asterisk-restart`
* `/etc/asterisk/scripts/asterisk-stop`