### PR TITLE
Fix asl-node-lookup TXT [remotebase] queries

### DIFF
--- a/bin/asl-node-lookup
+++ b/bin/asl-node-lookup
@@ -244,7 +244,7 @@ do_a $ASL_HOST
 
 # -----
 
-do_txt $ASL_HOST
+do_txt ${ASL_NODE}.nodes.allstarlink.org
 
 # -----
 


### PR DESCRIPTION
TXT record queries for "remotebase" nodes use the same domain name as all other nodes (NNNNN.nodes.allstarlink.org).