### PR TITLE
Spoken time doesn't make sense

### DIFF
--- a/bin/asl-say
+++ b/bin/asl-say
@@ -15,6 +15,7 @@
 BI_AUDIO="/usr/share/asterisk/sounds/en"
 CU_AUDIO="/var/lib/asterisk/sounds/en"
 
+DATE_ARG=""
 DATE_CMD="date"
 
 function ast_rx_lp(){
@@ -22,6 +23,12 @@ function ast_rx_lp(){
 }
 
 function build_and_say(){
+
+	if [[ -n "$ASL_SAY_TESTING" ]]; then
+		echo "[$DATE_ARG] $*"
+		exit
+	fi
+
 	TMPAUD=$(mktemp --suffix=.ulaw)
 	chmod 644 ${TMPAUD}
 	ASTAUD=$(echo ${TMPAUD} | sed -e 's/\.ulaw//g')
@@ -45,13 +52,13 @@ function build_and_say(){
 }
 
 function get_time(){
+	HOUR=$(eval $DATE_CMD +%I | sed -e 's/^0//')
+	MINUTE=$(eval $DATE_CMD +%M | sed -e 's/^0//')
 
-	# calculate the hour
-	HOUR=$($DATE_CMD +%I | sed -e 's/0//g')
+	# add the hour audio
 	HOUR_FULL="digits/${HOUR}"
 
-	# calculate the minute audio
-	MINUTE=$($DATE_CMD +%0M | sed -e s/'^0//')
+	# add the minute audio
 	if (( ${MINUTE} == 0 )); then
 		MINUTE_FULL="digits/oclock"
 	elif (( ${MINUTE} < 10 )); then
@@ -68,47 +75,53 @@ function get_time(){
 		fi
 	fi
 
-	# am/pm
-	AM_PM=$($DATE_CMD +%P | sed 's/^\([ap]\)\(m\)/\1-\2/')
+	# add am/pm
+	AM_PM=$(eval $DATE_CMD +%P | sed 's/^\([ap]\)\(m\)/\1-\2/')
 
-	# timezone with letters prefix
-	TIMEZONE=$($DATE_CMD +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
+	# add the timezone with letters prefix
+	TIMEZONE=$(eval $DATE_CMD +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
 
 	echo "rpt/thetimeis ${HOUR_FULL} ${MINUTE_FULL} digits/${AM_PM} ${TIMEZONE}"
 }
 
 function get_time24(){
+	HOUR=$(eval $DATE_CMD +%-H)
+	MINUTE=$(eval $DATE_CMD +%0M | sed -e 's/^0//')
 
-	# calculate the hour audio
-	HOUR=$($DATE_CMD +%-H)
-	if (( ${HOUR} < 20 )); then
-		HOUR_FULL="digits/${HOUR} hours"
+	# add the hour audio
+	if (( ${HOUR} == 0 )); then
+		HOUR_FULL="digits/0"
+	elif (( ${HOUR} < 10 )); then
+		HOUR_FULL="digits/oh digits/${HOUR}"
+	elif (( ${HOUR} < 20 )); then
+		HOUR_FULL="digits/${HOUR}"
 	else
 		A=$(( ${HOUR} / 10 ))
 		B=$(( ${HOUR} % 10 ))
 		if (( $B == 0 )); then
-			HOUR_FULL="digits/${A}0 hours"
+			HOUR_FULL="digits/${HOUR}"
 		else
-			HOUR_FULL="digits/${A}0 digits/${B} hours"
+			HOUR_FULL="digits/${A}0 digits/${B}"
 		fi
 	fi
 
-	# calculate the minute audio
-	MINUTE=$($DATE_CMD +%0M | sed -e s/'^0//')
-	if (( ${MINUTE} < 20 )); then
-		MINUTE_FULL="digits/${MINUTE} minutes"
+	# add the minute audio
+	if (( ${MINUTE} == 0 )); then
+		MINUTE_FULL="digits/hundred"
+	elif (( ${MINUTE} < 10 )); then
+		MINUTE_FULL="digits/oh digits/${MINUTE}"
 	else
 		A=$(( ${MINUTE} / 10 ))
 		B=$(( ${MINUTE} % 10 ))
-		if (( $B == 0 )); then
-			MINUTE_FULL="digits/${A}0 minutes"
+		if (( ${MINUTE} < 20 )); then
+			MINUTE_FULL="digits/${MINUTE}"
 		else
-			MINUTE_FULL="digits/${A}0 digits/${B} minutes"
+			MINUTE_FULL="digits/${A}0 digits/${B}"
 		fi
 	fi
 
-	# timezone with letters prefix
-	TIMEZONE=$($DATE_CMD +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
+	# add the timezone with letters prefix
+	TIMEZONE=$(eval $DATE_CMD +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
 
 	echo "rpt/thetimeis ${HOUR_FULL} ${MINUTE_FULL} ${TIMEZONE}"
 }
@@ -149,7 +162,9 @@ while getopts "n:w:d:" opt; do
 	case ${opt} in
 		n)	NODE="${OPTARG}" ;;
 		w)	WHAT="${OPTARG}" ;;
-		d)	DATE_CMD+=" --date=${OPTARG}" ;;
+		d)	DATE_ARG="-d \"${OPTARG}\""
+			DATE_CMD+=" $DATE_ARG"
+			;;
 		*)	usage ;;
 	esac
 done

--- a/bin/asl-say
+++ b/bin/asl-say
@@ -15,6 +15,11 @@
 BI_AUDIO="/usr/share/asterisk/sounds/en"
 CU_AUDIO="/var/lib/asterisk/sounds/en"
 
+# date/time (for testing with "-d yyyymmdd" and "-t hhmm"))
+ALT_DATE=""
+ALT_TIME=""
+ALT_DATE_TIME=""
+
 function ast_rx_lp(){
 	asterisk -rx "rpt localplay ${NODE} $1" 2>&1
 }
@@ -43,60 +48,72 @@ function build_and_say(){
 }
 
 function get_time(){
-	
-	# calculate the hour
-	NOW_H=$(date +%I | sed -e 's/0//g')
 
-	# calculate the minute audio	
-	NOW_M=$(date +%M | sed -e s/'^0//')
-	NOW_FM=$(( ${NOW_M} / 10 ))
-	case ${NOW_FM} in
-		0)	NOW_FM=0 ;;
-		1)	NOW_FM=$(date +%M) ;;
-		*)	NOW_FM="${NOW_FM}0" ;;
-	esac
-	NOW_SM=$(( ${NOW_M} % 10 ))
-	if [ $NOW_FM -eq 0 ] && [ $NOW_SM -eq 0 ]; then
-		$NOW_FM=oclock
-		$NOW_SM=""
+	# calculate the hour
+	NOW_H=$(date ${ALT_DATE_TIME} +%I | sed -e 's/0//g')
+	NOW_H_FULL="digits/${NOW_H}"
+
+	# calculate the minute audio
+	NOW_M=$(date ${ALT_DATE_TIME} +%0M | sed -e s/'^0//')
+	if (( ${NOW_M} == 0 )); then
+		NOW_M_FULL="digits/oclock"
+	elif (( ${NOW_M} < 10 )); then
+		NOW_M_FULL="digits/oh digits/${NOW_M}"
+	elif (( ${NOW_M} < 20 )); then
+		NOW_M_FULL="digits/${NOW_M}"
+	else
+		A=$(( ${NOW_M} / 10 ))
+		B=$(( ${NOW_M} % 10 ))
+		if (( $B == 0 )); then
+			NOW_M_FULL="digits/${A}0"
+		else
+			NOW_M_FULL="digits/${A}0 digits/${B}"
+		fi
 	fi
-	[ $NOW_FM -ge 1 ] && [ $NOW_FM -lt 20 ] && NOW_SM=""
 
 	# am/pm
-	NOW_A=$(date +%P | sed 's/^\([ap]\)\(m\)/\1-\2/')
+	NOW_A=$(date ${ALT_DATE_TIME} +%P | sed 's/^\([ap]\)\(m\)/\1-\2/')
 
 	# timezone with letters prefix
-	NOW_TZ=$(date +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
-	echo "rpt/thetimeis digits/${NOW_H} digits/${NOW_FM} \ 
-		digits/${NOW_SM} digits/${NOW_A} ${NOW_TZ}"
+	NOW_TZ=$(date ${ALT_DATE_TIME} +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
+
+	echo "rpt/thetimeis ${NOW_H_FULL} ${NOW_M_FULL} digits/${NOW_A} ${NOW_TZ}"
 }
 
 function get_time24(){
 
-	NOW_HR=$(date +%-H)
-	if (( 0 <= ${NOW_HR} && ${NOW_HR} < 19 )); then
-		NOW_HR_FULL="digits/${NOW_HR} hours"		
-	elif (( 20 <= ${NOW_HR } && ${NOW_HR} < 24 )); then
-		A=$(( ${NOW_HR} / 10 ))
-		B=$(( ${NOW_HR} % 10 ))
-		NOW_HR_FULL="digits/${A} digits/${B} hours" 
+	# calculate the hour audio
+	NOW_H=$(date ${ALT_DATE_TIME} +%-H)
+	if (( ${NOW_H} < 20 )); then
+		NOW_H_FULL="digits/${NOW_H} hours"
+	else
+		A=$(( ${NOW_H} / 10 ))
+		B=$(( ${NOW_H} % 10 ))
+		if (( $B == 0 )); then
+			NOW_H_FULL="digits/${A}0 hours"
+		else
+			NOW_H_FULL="digits/${A}0 digits/${B} hours"
+		fi
 	fi
-		
-    # calculate the minute audio
-    NOW_M=$(date +%-M | sed -e s/'^0//')
-	if (( $NOW_M == 0 )); then
-		NOW_MIN_FULL="digits/0 minutes"
-	elif (( 0 < ${NOW_M} && ${NOW_M} < 20 )); then
-		NOW_MIN_FULL="digits/${NOW_M} minutes"
-	else 
+
+	# calculate the minute audio
+	NOW_M=$(date ${ALT_DATE_TIME} +%0M | sed -e s/'^0//')
+	if (( ${NOW_M} < 20 )); then
+		NOW_M_FULL="digits/${NOW_M} minutes"
+	else
 		A=$(( ${NOW_M} / 10 ))
 		B=$(( ${NOW_M} % 10 ))
-		NOW_MIN_FULL="digits/${A}0 digits/${B} minutes"
+		if (( $B == 0 )); then
+			NOW_M_FULL="digits/${A}0 minutes"
+		else
+			NOW_M_FULL="digits/${A}0 digits/${B} minutes"
+		fi
 	fi
-	
+
 	# timezone with letters prefix
-	NOW_TZ=$(date +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
-	echo "rpt/thetimeis ${NOW_HR_FULL} ${NOW_MIN_FULL} ${NOW_TZ}"
+	NOW_TZ=$(date ${ALT_DATE_TIME} +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
+
+	echo "rpt/thetimeis ${NOW_H_FULL} ${NOW_M_FULL} ${NOW_TZ}"
 }
 
 function get_ip4(){
@@ -115,14 +132,14 @@ function get_ip4(){
 function get_ip6(){
 	IP=$(ip -6 addr | grep inet6 | awk -F '[ \t]+|/' '{print $3}' |\
 		 grep -v ^::1 | grep -v ^fe80)
-	 for e in $(echo ${IP} | sed 's/./& /g')
-    do
-        case $e in
-            :)  IP_SAY="${IP_SAY} letters/dot" ;;
-            [abcdef])  IP_SAY="${IP_SAY} letters/$e" ;;
+	for e in $(echo ${IP} | sed 's/./& /g')
+	do
+		case $e in
+			:)  IP_SAY="${IP_SAY} letters/dot" ;;
+			[abcdef])  IP_SAY="${IP_SAY} letters/$e" ;;
 			*)  IP_SAY="${IP_SAY} digits/$e" ;;
-        esac
-    done
+		esac
+	done
 	echo "letters/i letters/p digits/6 ${IP_SAY}"
 }
 
@@ -131,10 +148,12 @@ function usage(){
 	exit 1
 }
 
-while getopts "n:w:" opt; do
+while getopts "n:w:d:t:" opt; do
 	case ${opt} in
 		n)	NODE="${OPTARG}" ;;
 		w)	WHAT="${OPTARG}" ;;
+		d)	ALT_DATE="${OPTARG}" ;;
+		t)	ALT_TIME="${OPTARG}" ;;
 		*)	usage ;;
 	esac
 done
@@ -143,6 +162,29 @@ shift $((OPTIND-1))
 if [ -z "${NODE}" ] || [ ${NODE} -lt 1 ]; then
 	echo "-n {NODE} must be a number greater than 0" 1>&2
 	exit
+fi
+
+if [ -n "${ALT_DATE}${ALT_TIME}" ]; then
+	if [ -n "${ALT_DATE}" ]; then
+		re=^[0-9]{8}$
+		if ! [[ ${ALT_DATE} =~ $re ]]; then
+			echo "Alternate date must be YYYYMMDD"
+			exit 1
+		fi
+	else
+		ALT_DATE=$(date +%Y%m%d)
+	fi
+	if [ -n "${ALT_TIME}" ]; then
+		re=^[0-9]{4}$
+		if ! [[ ${ALT_TIME} =~ $re ]]; then
+			echo "Alternate time must be HHMM"
+			exit 1
+		fi
+	else
+		ALT_TIME=$(date +%H%M)
+	fi
+	touch -t "${ALT_DATE}${ALT_TIME}" /tmp/asl-say-date-reference
+	ALT_DATE_TIME="-r /tmp/asl-say-date-reference"
 fi
 
 case ${WHAT} in

--- a/bin/asl-say
+++ b/bin/asl-say
@@ -15,10 +15,7 @@
 BI_AUDIO="/usr/share/asterisk/sounds/en"
 CU_AUDIO="/var/lib/asterisk/sounds/en"
 
-# date/time (for testing with "-d yyyymmdd" and "-t hhmm"))
-ALT_DATE=""
-ALT_TIME=""
-ALT_DATE_TIME=""
+DATE_CMD="date"
 
 function ast_rx_lp(){
 	asterisk -rx "rpt localplay ${NODE} $1" 2>&1
@@ -50,70 +47,70 @@ function build_and_say(){
 function get_time(){
 
 	# calculate the hour
-	NOW_H=$(date ${ALT_DATE_TIME} +%I | sed -e 's/0//g')
-	NOW_H_FULL="digits/${NOW_H}"
+	HOUR=$($DATE_CMD +%I | sed -e 's/0//g')
+	HOUR_FULL="digits/${HOUR}"
 
 	# calculate the minute audio
-	NOW_M=$(date ${ALT_DATE_TIME} +%0M | sed -e s/'^0//')
-	if (( ${NOW_M} == 0 )); then
-		NOW_M_FULL="digits/oclock"
-	elif (( ${NOW_M} < 10 )); then
-		NOW_M_FULL="digits/oh digits/${NOW_M}"
-	elif (( ${NOW_M} < 20 )); then
-		NOW_M_FULL="digits/${NOW_M}"
+	MINUTE=$($DATE_CMD +%0M | sed -e s/'^0//')
+	if (( ${MINUTE} == 0 )); then
+		MINUTE_FULL="digits/oclock"
+	elif (( ${MINUTE} < 10 )); then
+		MINUTE_FULL="digits/oh digits/${MINUTE}"
+	elif (( ${MINUTE} < 20 )); then
+		MINUTE_FULL="digits/${MINUTE}"
 	else
-		A=$(( ${NOW_M} / 10 ))
-		B=$(( ${NOW_M} % 10 ))
+		A=$(( ${MINUTE} / 10 ))
+		B=$(( ${MINUTE} % 10 ))
 		if (( $B == 0 )); then
-			NOW_M_FULL="digits/${A}0"
+			MINUTE_FULL="digits/${A}0"
 		else
-			NOW_M_FULL="digits/${A}0 digits/${B}"
+			MINUTE_FULL="digits/${A}0 digits/${B}"
 		fi
 	fi
 
 	# am/pm
-	NOW_A=$(date ${ALT_DATE_TIME} +%P | sed 's/^\([ap]\)\(m\)/\1-\2/')
+	AM_PM=$($DATE_CMD +%P | sed 's/^\([ap]\)\(m\)/\1-\2/')
 
 	# timezone with letters prefix
-	NOW_TZ=$(date ${ALT_DATE_TIME} +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
+	TIMEZONE=$($DATE_CMD +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
 
-	echo "rpt/thetimeis ${NOW_H_FULL} ${NOW_M_FULL} digits/${NOW_A} ${NOW_TZ}"
+	echo "rpt/thetimeis ${HOUR_FULL} ${MINUTE_FULL} digits/${AM_PM} ${TIMEZONE}"
 }
 
 function get_time24(){
 
 	# calculate the hour audio
-	NOW_H=$(date ${ALT_DATE_TIME} +%-H)
-	if (( ${NOW_H} < 20 )); then
-		NOW_H_FULL="digits/${NOW_H} hours"
+	HOUR=$($DATE_CMD +%-H)
+	if (( ${HOUR} < 20 )); then
+		HOUR_FULL="digits/${HOUR} hours"
 	else
-		A=$(( ${NOW_H} / 10 ))
-		B=$(( ${NOW_H} % 10 ))
+		A=$(( ${HOUR} / 10 ))
+		B=$(( ${HOUR} % 10 ))
 		if (( $B == 0 )); then
-			NOW_H_FULL="digits/${A}0 hours"
+			HOUR_FULL="digits/${A}0 hours"
 		else
-			NOW_H_FULL="digits/${A}0 digits/${B} hours"
+			HOUR_FULL="digits/${A}0 digits/${B} hours"
 		fi
 	fi
 
 	# calculate the minute audio
-	NOW_M=$(date ${ALT_DATE_TIME} +%0M | sed -e s/'^0//')
-	if (( ${NOW_M} < 20 )); then
-		NOW_M_FULL="digits/${NOW_M} minutes"
+	MINUTE=$($DATE_CMD +%0M | sed -e s/'^0//')
+	if (( ${MINUTE} < 20 )); then
+		MINUTE_FULL="digits/${MINUTE} minutes"
 	else
-		A=$(( ${NOW_M} / 10 ))
-		B=$(( ${NOW_M} % 10 ))
+		A=$(( ${MINUTE} / 10 ))
+		B=$(( ${MINUTE} % 10 ))
 		if (( $B == 0 )); then
-			NOW_M_FULL="digits/${A}0 minutes"
+			MINUTE_FULL="digits/${A}0 minutes"
 		else
-			NOW_M_FULL="digits/${A}0 digits/${B} minutes"
+			MINUTE_FULL="digits/${A}0 digits/${B} minutes"
 		fi
 	fi
 
 	# timezone with letters prefix
-	NOW_TZ=$(date ${ALT_DATE_TIME} +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
+	TIMEZONE=$($DATE_CMD +%Z | tr '[A-Z]' '[a-z]' | sed 's/./letters\/& /g')
 
-	echo "rpt/thetimeis ${NOW_H_FULL} ${NOW_M_FULL} ${NOW_TZ}"
+	echo "rpt/thetimeis ${HOUR_FULL} ${MINUTE_FULL} ${TIMEZONE}"
 }
 
 function get_ip4(){
@@ -148,12 +145,11 @@ function usage(){
 	exit 1
 }
 
-while getopts "n:w:d:t:" opt; do
+while getopts "n:w:d:" opt; do
 	case ${opt} in
 		n)	NODE="${OPTARG}" ;;
 		w)	WHAT="${OPTARG}" ;;
-		d)	ALT_DATE="${OPTARG}" ;;
-		t)	ALT_TIME="${OPTARG}" ;;
+		d)	DATE_CMD+=" --date=${OPTARG}" ;;
 		*)	usage ;;
 	esac
 done
@@ -162,29 +158,6 @@ shift $((OPTIND-1))
 if [ -z "${NODE}" ] || [ ${NODE} -lt 1 ]; then
 	echo "-n {NODE} must be a number greater than 0" 1>&2
 	exit
-fi
-
-if [ -n "${ALT_DATE}${ALT_TIME}" ]; then
-	if [ -n "${ALT_DATE}" ]; then
-		re=^[0-9]{8}$
-		if ! [[ ${ALT_DATE} =~ $re ]]; then
-			echo "Alternate date must be YYYYMMDD"
-			exit 1
-		fi
-	else
-		ALT_DATE=$(date +%Y%m%d)
-	fi
-	if [ -n "${ALT_TIME}" ]; then
-		re=^[0-9]{4}$
-		if ! [[ ${ALT_TIME} =~ $re ]]; then
-			echo "Alternate time must be HHMM"
-			exit 1
-		fi
-	else
-		ALT_TIME=$(date +%H%M)
-	fi
-	touch -t "${ALT_DATE}${ALT_TIME}" /tmp/asl-say-date-reference
-	ALT_DATE_TIME="-r /tmp/asl-say-date-reference"
 fi
 
 case ${WHAT} in


### PR DESCRIPTION
For example: "thirteen hours and thirty zero minutes"

Also, added a way to "test" the spoken time for any given time via new "-d STRING" argument (that follows the `date` commands "--date=STRING" argument),

Note: the "-d" argument is not included in the help/usage