### PR TITLE
Require --force-confold for dpkg upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ RELPLAT ?= deb$(shell lsb_release -rs 2> /dev/null)
 
 BUILDABLES = \
 	bin \
+	apt.conf.d \
 	keys \
 	polkit \
 	share

--- a/apt.conf.d/99asl-confold
+++ b/apt.conf.d/99asl-confold
@@ -1,0 +1,4 @@
+Dpkg::Options {
+    "--force-confold";
+};
+

--- a/apt.conf.d/Makefile
+++ b/apt.conf.d/Makefile
@@ -1,0 +1,13 @@
+sysconfdir ?= /etc/apt.conf.d/
+
+CONF_FILES = $(filter-out Makefile tmp , $(wildcard *))
+CONF_INSTALLABLES = $(patsubst %, $(DESTDIR)$(sysconfdir)/%, $(CONF_FILES))
+
+INSTALLABLES = $(CONF_INSTALLABLES) 
+
+.PHONY:	install
+install:	$(INSTALLABLES)
+
+$(DESTDIR)$(sysconfdir)/%: %
+	install -D -m 0644  $< $@
+

--- a/apt.conf.d/Makefile
+++ b/apt.conf.d/Makefile
@@ -1,4 +1,4 @@
-sysconfdir ?= /etc/apt.conf.d/
+sysconfdir ?= /etc/apt/apt.conf.d/
 
 CONF_FILES = $(filter-out Makefile tmp , $(wildcard *))
 CONF_INSTALLABLES = $(patsubst %, $(DESTDIR)$(sysconfdir)/%, $(CONF_FILES))


### PR DESCRIPTION
Unconditionally set `--force-confold` for dpkg operations