### PR TITLE
asl-check-install: Add the asl-check-install script for Troubleshooting Help

### DIFF
--- a/bin/asl-check-install
+++ b/bin/asl-check-install
@@ -6,7 +6,7 @@
 # Control the path so we control the scripts that are run
 export PATH="/usr/bin:/usr/sbin:/sbin:/bin"
 
-if [ ${USER} != "root" ]; then
+if [ ${EUID} -ne 0 ]; then
 	printf "This must be run as root\n"
 fi
 

--- a/bin/asl-check-install
+++ b/bin/asl-check-install
@@ -1,0 +1,94 @@
+#!/usr/bin/bash
+#
+# Check the installation of ASL3 and (optionally)
+# attempt to fix errors with it
+
+# Control the path so we control the scripts that are run
+export PATH="/usr/bin:/usr/sbin:/sbin:/bin"
+
+if [ ${USER} != "root" ]; then
+	printf "This must be run as root\n"
+fi
+
+# First, display the currently installed packages
+printf "\n\n"
+printf "\n=====================================================================\n\n"
+printf "\nII   Gathering asl-show-version information\n\n"
+
+asl-show-version
+
+printf "\n=====================================================================\n\n"
+printf "II   Checking Kernel and DAHDI status\n\n"
+
+##
+## Check for DAHDI/Kernel issues
+##
+
+PLATFORM_ARCH=$(uname -m)
+
+case ${PLATFORM_ARCH} in
+	x86_64)
+		DEBIAN_ARCH=amd64
+		;;
+	aarch64)
+		DEBIAN_ARCH=arm64
+		;;
+	*)
+		printf "EE   Unsupported hardware platform!\n\n"
+		;;
+esac
+
+RUNNING_KERNEL=$(uname -r)
+	
+DAHDI_ERRORS=0
+DAHDI_NUM_MODS=$(find /lib/modules/$(uname -r) -name '*dahdi*' | wc -l)
+[ ${DAHDI_NUM_MODS} -lt 1 ] && DAHDI_ERRORS=1
+
+if [ ${DAHDI_ERRORS} -ne 0 ]; then
+	printf "EE   Missing one or more DAHDI modules in the running kernel...\n"	
+
+
+	if ! `dpkg -l 'linux-headers*' | grep -vE '^(rc|un)' | grep -q ${RUNNING_KERNEL}`; then
+		printf "EE   Missing package linux-headers-${RUNNING_KERNEL}\n"
+	fi
+
+	printf "\n"
+	printf "??   Do you want to try to fix the issue? (y/N):  "
+	read DAHDI_FIX
+	if [ "${DAHDI_FIX}" == "y" ] || [ "${DAHDI_FIX}" == "Y" ]; then
+		printf "~~   ===== DOING APT THINGS ==========================\n\n"
+		apt update
+		apt install --reinstall -y linux-headers-${DEBIAN_ARCH} \
+			linux-headers-${RUNNING_KERNEL} dahdi-linux dahdi-dkms
+		printf "~~   ===== END OF APT THINGS =========================\n\n"		
+		
+		modprobe dahdi
+		modprobe dahdi_transcode
+		modprobe dahdi_dummy
+
+		DAHDI_NUM_MODS=$(find /lib/modules/$(uname -r) -name '*dahdi*' | wc -l)
+		if [ ${DAHDI_NUM_MODS} -lt 1 ]; then
+			printf "EE   Reinstalling headers and DAHDI did **NOT** succeeed"
+		fi
+
+	else
+		printf "II   Skipping fixing DAHDI kernel\n\n"
+	fi
+else
+	printf "II   No kernel or DAHDI issues detected\n"
+fi
+
+printf "\n=====================================================================\n\n"
+
+LOG_ERR_CNT=$(grep -E '\] ERROR' /var/log/asterisk/messages.log | wc -l)
+
+if [ ${LOG_ERR_CNT} -gt 0 ]; then
+	printf "EE   The following errors are present in /var/log/asterisk/messages\n\n"
+
+	grep -E '\] (Asterisk|ERROR)' /var/log/asterisk/messages.log
+else
+	printf "II   There are no errors in /var/log/asterisk/messages\n\n"
+fi
+
+printf "\n\nNN   The above can be pasted into a forum post or a GitHub issue\n\n"
+exit 0

--- a/bin/asl-check-install.1.md
+++ b/bin/asl-check-install.1.md
@@ -1,0 +1,19 @@
+% asl-check-install(1) ASL3 @@HEAD-DEVELOP@@
+% Jason McCormick, Allan Nathanson
+% June 2025
+
+# NAME
+asl-check-install - Display and potentially fix ASL3 issues
+
+# SYNOPSIS
+usage: `asl-check-install`
+
+# DESCRIPTION
+asl-check-install - Display and potentially fix ASL3 issues
+
+# BUGS
+Report bugs to https://github.com/AllStarLink/ASL3/issues
+
+# COPYRIGHT
+Copyright (C) 2025 Jason McCormick and AllStarLink
+under the terms of the AGPL v3.

--- a/bin/asl-check-install.1.md
+++ b/bin/asl-check-install.1.md
@@ -1,6 +1,6 @@
 % asl-check-install(1) ASL3 @@HEAD-DEVELOP@@
-% Jason McCormick, Allan Nathanson
-% June 2025
+% Jason McCormick
+% April 2025
 
 # NAME
 asl-check-install - Display and potentially fix ASL3 issues


### PR DESCRIPTION
This script is the basis for adding troubleshooting of problems as we run into them.