### PR TITLE
sa818, sa818-menu: allow CTCSS split (on tone "on", one tone "off")

### DIFF
--- a/bin/sa818
+++ b/bin/sa818
@@ -44,23 +44,146 @@ logging.basicConfig(format='%(name)s: %(levelname)s: %(message)s',
 logger = logging.getLogger('SA818')
 
 
+#
+# SA818 CTCSS Tone Frequencies (0000-0038)
+#
 CTCSS = (
-  "None", "67.0", "71.9", "74.4", "77.0", "79.7", "82.5", "85.4", "88.5",
-  "91.5", "94.8", "97.4", "100.0", "103.5", "107.2", "110.9", "114.8", "118.8",
-  "123.0", "127.3", "131.8", "136.5", "141.3", "146.2", "151.4", "156.7",
-  "162.2", "167.9", "173.8", "179.9", "186.2", "192.8", "203.5", "210.7",
-  "218.1", "225.7", "233.6", "241.8", "250.3"
+  "None", "67.0", "71.9", "74.4", "77.0", "79.7", "82.5", "85.4", "88.5", "91.5",  # 0000-0009
+  "94.8", "97.4", "100.0","103.5","107.2","110.9","114.8","118.8","123.0","127.3", # 0010-0019
+  "131.8","136.5","141.3","146.2","151.4","156.7","162.2","167.9","173.8","179.9", # 0020-0029
+  "186.2","192.8","203.5","210.7","218.1","225.7","233.6","241.8","250.3"          # 0030-0038
 )
 
+#
+# SA818 CDCSS Tone Frequencies (None, 83*xxxI, 83*xxxN)
+#
 DCS_CODES = [
-  "023", "025", "026", "031", "032", "036", "043", "047", "051", "053", "054",
-  "065", "071", "072", "073", "074", "114", "115", "116", "125", "131", "132",
-  "134", "143", "152", "155", "156", "162", "165", "172", "174", "205", "223",
-  "226", "243", "244", "245", "251", "261", "263", "265", "271", "306", "311",
-  "315", "331", "343", "346", "351", "364", "365", "371", "411", "412", "413",
-  "423", "431", "432", "445", "464", "465", "466", "503", "506", "516", "532",
-  "546", "565", "606", "612", "624", "627", "631", "632", "654", "662", "664",
-  "703", "712", "723", "731", "732", "734", "743", "754"
+  "023", "025", "026", "031", "032", "043", "047", "051", "054", "065",
+  "071", "072", "073", "074", "114", "115", "116", "125", "131", "132",
+  "134", "143", "152", "155", "156", "162", "165", "172", "174", "205",
+  "223", "226", "243", "244", "245", "251", "261", "263", "265", "271",
+  "306", "311", "315", "331", "343", "346", "351", "364", "365", "371",
+  "411", "412", "413", "423", "431", "432", "445", "464", "465", "466",
+  "503", "506", "516", "532", "546", "565", "606", "612", "624", "627",
+  "631", "632", "654", "662", "664", "703", "712", "723", "731", "732",
+  "734", "743", "754",
+]
+
+#
+# DCS info:
+#
+# SA818_programming_manual.pdf
+# https://web.archive.org/web/20220331074737/http://www.onfreq.com/syntorx/dcs.html
+# https://www.ccareswa.org/system/files/library/2020-07-20_CTCSS%2BDCS-presentation_Rev1_WA7PTM.pdf
+#
+
+DCS_CODES_EXTENDED = [
+  #
+  # Extended (21*xxxI, 21*xxxN)
+  #
+                       "036", "053", "122", "145", "212", "225", "246",
+  "252", "255", "266", "274", "325", "332", "356", "446", "452", "454",
+  "455", "462", "523", "526"
+]
+
+DCS_CODES_NONSTANDARD = [
+  #
+  # Non-standard code groupings (including the "extended" codes above)
+  #
+  "000", "352",
+  "001", "476", "760",
+  "002", "522", "540",
+  "003", "100",
+  "004", "300", "334",
+  "005", "044", "400",
+  "006",
+  "007", "670",
+  "010", "033", "600",
+  "011", "401", "531", "625",
+  "012", "215", "320",
+  "013", "063", "700",
+  "014", "450", "500", "544",
+  "015", "740", "747",
+  "016", "154", "206",
+  "017", "200",
+  "020", "170", "230", "601",
+  "021", "277", "402",
+  "022", "264", "461", "613",
+  "024", "120", "260",
+  "027", "201", "242",
+  "030", "055",
+  "034", "103", "140", "410",
+  "035", "124", "403",
+  "036", "137",
+  "040", "052", "404",
+  "041", "111", "451", "514", "602",
+  "042", "160", "216", "341",
+  "045", "240", "305", "543",
+  "046", "202", "210", "421", "644",
+  "050", "167",
+  "053",
+  "061", "211", "232", "650",
+  "062", "070", "101", "407",
+  "064", "151", "440", "406",
+  "077",
+  "102", "121", "323", "604",
+  "105", "204", "247", "420", "710",
+  "106", "221", "241", "304", "424",
+  "110", "126", "302", "430",
+  "112", "250", "505", "512",
+  "113", "573",
+  "122", "535",
+  "141", "177", "541",
+  "145", "525",
+  "146", "220", "414", "422", "442", "622",
+  "166", "773",
+  "175",
+  "212", "253",
+  "214", "310", "377", "437",
+  "225", "536",
+  "246", "542", "653",
+  "252", "661",
+  "255", "425",
+  "257", "705",
+  "266", "655",
+  "272",
+  "274", "652",
+  "275",
+  "325", "550", "626",
+  "332", "433", "552",
+  "335",
+  "336", "770",
+  "337",
+  "347", "434", "776",
+  "356", "521",
+  "357", "477", "774",
+  "361", "373",
+  "367", "676",
+  "376", "617", "763",
+  "446", "467", "511", "672",
+  "452", "524", "765",
+  "454", "545", "513", "564",
+  "455", "533", "551",
+  "462", "472", "623", "725",
+  "463", "637", "775",
+  "523", "647", "726",
+  "526", "562", "645",
+  "527", "764",
+  "537", "735",
+  "547", "757",
+  "555", "571",
+  "556",
+  "576", "722",
+  "577",
+  "633", "667",
+  "646", "665",
+  "651", "677",
+  "716", "727",
+  "733",
+  "752", "755",
+  "753",
+  "767",
+  "777"
 ]
 
 BAUD_RATES = [300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200]
@@ -153,6 +276,7 @@ class SA818:
     return version
 
   def set_radio(self, frequency, offset, bw, squelch, ctcss, dcs, tail):
+    # pylint: disable=too-many-locals,too-many-positional-arguments
     tone = ctcss if ctcss else dcs
     if tone:                # 0000 = No ctcss or dcs tone
       tx_tone, rx_tone = tone
@@ -178,9 +302,11 @@ class SA818:
         logger.info(msg, response, bw_label, rx_freq, tx_freq,
                     CTCSS[int(tx_tone)], CTCSS[int(rx_tone)], squelch)
       elif dcs:
-        msg = "%s, BW: %s Frequency (RX: %s / TX: %s), DCD (TX: %s / RX: %s), squelch: %s, OK"
+        tx_tone_display = None if tx_tone == '0000' else tx_tone
+        rx_tone_display = None if rx_tone == '0000' else rx_tone
+        msg = "%s, BW: %s Frequency (RX: %s / TX: %s), DCS (TX: %s / RX: %s), squelch: %s, OK"
         logger.info(msg, response, bw_label, rx_freq, tx_freq,
-                    tx_tone, rx_tone, squelch)
+                    tx_tone_display, rx_tone_display, squelch)
       else:
         msg = "%s, BW: %s, RX frequency: %s, TX frequency: %s, squelch: %s, OK"
         logger.info(msg, response, bw_label, rx_freq, tx_freq, squelch)
@@ -248,15 +374,20 @@ def type_ctcss(parg):
     raise argparse.ArgumentError from None
 
   for code in codes:
-    try:
-      ctcss = str(float(code))
-      if ctcss not in CTCSS:
-        raise ValueError
-      ctcss = CTCSS.index(ctcss)
-      tone_codes.append(f"{ctcss:04d}")
-    except ValueError:
-      logger.error(err_msg)
-      raise argparse.ArgumentTypeError from None
+    if code.lower() == "none":
+      tone_codes.append("0000")  # No CTCSS
+    else:
+      try:
+        ctcss = str(float(code))
+        if ctcss == "0.0":
+          ctcss == CTCSS[0]
+        if ctcss not in CTCSS:
+          raise ValueError
+        ctcss = CTCSS.index(ctcss)
+        tone_codes.append(f"{ctcss:04d}")
+      except ValueError:
+        logger.error(err_msg)
+        raise argparse.ArgumentTypeError from None
 
   return tone_codes
 
@@ -272,19 +403,27 @@ def type_dcs(parg):
     raise argparse.ArgumentError from None
 
   for code in codes:
-    if code[-1] not in ('N', 'I'):
-      logger.error(err_msg)
-      raise argparse.ArgumentError from None
-
-    code, direction = code[:-1], code[-1]
-    try:
-      dcs = f"{int(code):03d}"
-      if dcs not in DCS_CODES:
+    if code.lower() == "none":
+      dcs_codes.append("0000")  # No DCS
+    else:
+      if code[-1] not in ('N', 'I'):
         logger.error(err_msg)
-        raise argparse.ArgumentError
-    except ValueError:
-      raise argparse.ArgumentTypeError from None
-    dcs_codes.append(dcs + direction)
+        raise argparse.ArgumentError from None
+
+      code, direction = code[:-1], code[-1]
+      try:
+        dcs = f"{int(code):03d}"
+        if dcs not in DCS_CODES:
+          if dcs in DCS_CODES_EXTENDED:
+            logger.info("Setting extended DCS code: %s", dcs + direction)
+          elif dcs in DCS_CODES_NONSTANDARD:
+            logger.info("Setting non-standard DCS code: %s", dcs + direction)
+          else:
+            logger.error(err_msg)
+            raise argparse.ArgumentError
+      except ValueError:
+        raise argparse.ArgumentTypeError from None
+      dcs_codes.append(dcs + direction)
 
   return dcs_codes
 
@@ -382,7 +521,7 @@ def command_parser():
                        help="Squelch value (0 to 8) [default: %(default)s]")
   code_group = p_radio.add_mutually_exclusive_group()
   code_group.add_argument("--ctcss", default=None, type=type_ctcss,
-                          help="CTCSS (PL Tone) 0 for no CTCSS [default: %(default)s]")
+                          help="CTCSS (PL Tone) \"None\" for no CTCSS [default: %(default)s]")
   code_group.add_argument("--dcs", default=None, type=type_dcs,
                           help=("DCS code must be the number followed by [N normal] or "
                                 "[I inverse]  [default: %(default)s]"))

--- a/bin/sa818-menu
+++ b/bin/sa818-menu
@@ -91,6 +91,7 @@ do_settings_load() {
     if [ -r "${SA818_CONF}" ]; then
 	. "${SA818_CONF}"
     fi
+
     CURRENT_BAND=${CURRENT_BAND:-"VHF"}
     CURRENT_BANDWIDTH=${CURRENT_BANDWIDTH:-"Wide"}
     CURRENT_FREQ_RX=${CURRENT_FREQ_RX:-"000.0000"}
@@ -100,14 +101,23 @@ do_settings_load() {
     CURRENT_TONE=${CURRENT_TONE:-"None"}
     CURRENT_CTCSS_RX=${CURRENT_CTCSS_RX:-"None"}
     CURRENT_CTCSS_TX=${CURRENT_CTCSS_TX:-"None"}
-    CURRENT_DCS_RX=${CURRENT_DCS_RX:-""}
-    CURRENT_DCS_TX=${CURRENT_DCS_TX:-""}
+    CURRENT_DCS_RX=${CURRENT_DCS_RX:-"None"}
+    CURRENT_DCS_TX=${CURRENT_DCS_TX:-"None"}
     CURRENT_TAIL_TONE=${CURRENT_TAIL_TONE:-"Closed"}
     CURRENT_EMPHASIS=${CURRENT_EMPHASIS:-"Disabled"}
     CURRENT_FILTER_HIGH_PASS=${CURRENT_FILTER_HIGH_PASS:-"Disabled"}
     CURRENT_FILTER_LOW_PASS=${CURRENT_FILTER_LOW_PASS:-"Disabled"}
     CURRENT_PORT=${CURRENT_PORT:-""}
     CURRENT_SPEED=${CURRENT_SPEED:-""}
+
+    if [[ "$CURRENT_DCS_RX" = "" ]]; then
+	CURRENT_DCS_RX="None"
+    fi
+    if [[ "$CURRENT_DCS_TX" = "" ]]; then
+	CURRENT_DCS_TX="None"
+    fi
+
+    STORED_TONE=$CURRENT_TONE
 }
 
 do_settings_store() {
@@ -182,7 +192,7 @@ do_sa818_update_radio() {
     #                         Receive frequency
     #   --offset OFFSET       Offset in MHz, 0 for no offset [default: 0.0]
     #   --squelch SQUELCH     Squelch value (0 to 8) [default: 4]
-    #   --ctcss CTCSS         CTCSS (PL Tone) 0 for no CTCSS [default: None]
+    #   --ctcss CTCSS         CTCSS (PL Tone) "None" for no CTCSS [default: None]
     #   --dcs DCS             DCS code must be the number followed by [N normal] or [I inverse] [default: None]
     #   --tail TAIL           Close CTCSS Tail Tone (Open/Close)
     #
@@ -212,14 +222,25 @@ do_sa818_update_radio() {
 		else
 		    sa818_cmd+=("--tail"  "close")
 		fi
+	    else
+		sa818_cmd+=("--ctcss" "None,None")
 	    fi
 	    ;;
 	"DCS" )
-	    if [[ "$CURRENT_DCS_RX" != "" || "$CURRENT_DCS_TX" != "" ]]; then
+	    if [[ "$CURRENT_DCS_RX" != "None" || "$CURRENT_DCS_TX" != "None" ]]; then
 		sa818_cmd+=("--dcs" "$CURRENT_DCS_TX,$CURRENT_DCS_RX")
+	    else
+		sa818_cmd+=("--dcs" "None,None")
+	    fi
+	    ;;
+	* )
+	    if [[ "$CURRENT_TONE" != "$STORED_TONE" ]]; then
+		# ensure that any current tones are removed
+		sa818_cmd+=("--ctcss" "None,None")
 	    fi
 	    ;;
     esac
+    STORED_TONE="$CURRENT_TONE"
 
     echo ""
     echo "# ${sa818_cmd[@]}"
@@ -299,7 +320,11 @@ do_sa818_update() {
 	return 0
     fi
 
-    sa818_cmd_base=("sa818")
+    if [ -x "$(dirname $0)/sa818" ]; then
+	sa818_cmd_base=("$(dirname $0)/sa818")
+    else
+	sa818_cmd_base=("sa818")
+    fi
     if [[ -n "$ASL_DEBUG" ]]; then
 	sa818_cmd_base+=("$ASL_DEBUG")
     fi
@@ -439,27 +464,6 @@ CTCSS_TONES=(										\
 		"218.1" "225.7" "233.6" "241.8" "250.3"					\
 	    )
 
-#
-#   ctcss_index $ANSWER
-#   if [[ $? -ne 0 ]]; then
-#	echo "CTCSS tone index = $SA818_CTCSS_TONE"
-#	sleep 5
-#   fi
-#
-ctcss_index() {
-    CURRENT_CTCSS=$1
-
-    # Loop through the array
-    for i in "${!CTCSS_TONES[@]}"; do
-	if [[ "${CTCSS_TONES[$i]}" = "$CURRENT_CTCSS" ]]; then
-	    SA818_CTCSS_TONE=$(printf "%.4d" "$i")
-	    return 1
-	fi
-    done
-
-    return 0
-}
-
 do_ctcss_select() {
     echo "doing do_ctcss_select"			>>$logfile
 
@@ -518,6 +522,14 @@ do_dcs_select() {
     CURRENT_DCS=$2
 
     dcs_codes=()
+
+    if [[ "$CURRENT_DCS" = "None" ]]; then
+	ONOFF="ON"
+    else
+	ONOFF="OFF"
+    fi
+    dcs_codes+=("None" "$ONOFF")
+
     for t in "${DCS_CODES[@]}"; do
 	for x in "I" "N"; do
 	    code="$t$x"
@@ -544,7 +556,6 @@ do_dcs_select() {
 	return 0
     fi
 
-    ANSWER="${ANSWER% Hz}"
     return 1
 }
 
@@ -772,8 +783,8 @@ do_update_rx_ctcss() {
 
     if [[ $ANSWER != $CURRENT_CTCSS_RX ]]; then
 	CURRENT_CTCSS_RX=$ANSWER
-	if [[ "$ANSWER" = "None" || "$CURRENT_CTCSS_TX" = "None" ]]; then
-	    # if setting to (or from) "None", set both
+	if [[ "$ANSWER" != "None" && "$CURRENT_CTCSS_TX" = "None" ]]; then
+	    # if both were "None", set both to the new tone
 	    CURRENT_CTCSS_TX=$ANSWER
 	fi
 	SA818_UPDATED=1
@@ -792,8 +803,8 @@ do_update_tx_ctcss() {
 
     if [[ $ANSWER != $CURRENT_CTCSS_TX ]]; then
 	CURRENT_CTCSS_TX=$ANSWER
-	if [[ "$ANSWER" = "None" || "$CURRENT_CTCSS_RX" = "None" ]]; then
-	    # if setting to (or from) "None", set both
+	if [[ "$ANSWER" != "None" && "$CURRENT_CTCSS_RX" = "None" ]]; then
+	    # if both were "None", set both to the new tone
 	    CURRENT_CTCSS_RX=$ANSWER
 	fi
 	SA818_UPDATED=1
@@ -812,8 +823,8 @@ do_update_rx_dcs() {
 
     if [[ $ANSWER != $CURRENT_DCS_RX ]]; then
 	CURRENT_DCS_RX=$ANSWER
-	if [[ "$CURRENT_DCS_TX" = "" ]]; then
-	    # if changing from "", set both
+	if [[ "$ANSWER" != "None" && "$CURRENT_DCS_TX" = "None" ]]; then
+	    # if both were "None", set both to the new tone
 	    CURRENT_DCS_TX=$ANSWER
 	fi
 	SA818_UPDATED=1
@@ -832,8 +843,8 @@ do_update_tx_dcs() {
 
     if [[ $ANSWER != $CURRENT_DCS_TX ]]; then
 	CURRENT_DCS_TX=$ANSWER
-	if [[ "$CURRENT_DCS_RX" = "" ]]; then
-	    # if changing from "", set both
+	if [[ "$ANSWER" != "None" && "$CURRENT_DCS_RX" = "None" ]]; then
+	    # if both were "None", set both to the new tone
 	    CURRENT_DCS_RX=$ANSWER
 	fi
 	SA818_UPDATED=1
@@ -1008,6 +1019,15 @@ do_update_speed() {
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
 
+do_refresh_rf_module() {
+    echo "doing do_refresh_rf_module"		>>$logfile
+
+    STORED_TONE="Force Update"
+    SA818_UPDATED=1
+}
+
+# ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+
 do_main_menu() {
     echo "do_main_menu"				>>$logfile
 
@@ -1089,6 +1109,8 @@ do_main_menu() {
 	    ""  ""									\
 	    "P" "Serial Port                     : $DISPLAY_PORT"			\
 	    "S" "Connection Speed                : $DISPLAY_SPEED"			\
+	    ""  ""									\
+	    "R" "Refresh RF Module"							\
 	    3>&1 1>&2 2>&3)
 	RC=$?
 	if [[ $RC -ne 0 ]]; then
@@ -1140,6 +1162,8 @@ do_main_menu() {
 		;;
 	    S )	do_update_speed
 		;;
+	    R )	do_refresh_rf_module
+		;;
 	    "" )
 		;;
 	    * )	whiptail --msgbox "$CHOICE is an unrecognized selection." $MSGBOX_HEIGHT $MSGBOX_WIDTH
@@ -1154,11 +1178,12 @@ do_main_menu() {
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
 
 usage() {
-    echo "Usage: $0 [ --apply ] [ --debug ]"
+    echo "Usage: $0 [ --conf <config-file> ] [ --apply ] [ --debug ]"
     echo ""
     echo "Options :"
-    echo "  --apply	[Re-]apply the saved configuration to SA818 (without the menu)"
-    echo "  --debug	Enable \"sa818\" debugging"
+    echo "  --conf <config-file>  \"saved\" configuration file (default /etc/sa818.conf)"
+    echo "  --apply               [Re-]apply the \"saved\" configuration to SA818 (without the menu)"
+    echo "  --debug               Enable \"sa818\" debugging"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -1166,6 +1191,15 @@ while [[ $# -gt 0 ]]; do
 	"--apply" )
 	    SA818_APPLY=1
 	    shift
+	    ;;
+
+	"--conf" )
+	    if [[ $# -lt 2 ]]; then
+		usage
+		exit 1
+	    fi
+	    SA818_CONF="$2"
+	    shift; shift
 	    ;;
 
 	"--debug" )

--- a/bin/sa818-menu.1.md
+++ b/bin/sa818-menu.1.md
@@ -7,14 +7,16 @@
 Usage: 
 
 ```
-/usr/bin/sa818-menu [-h] [--apply] [--debug]
+/usr/bin/sa818-menu [-h] [--conf <config-file>] [--apply] [--debug]
 ```
 
 Optional arguments:
 
 `-h`: show usage help
 
-`--apply`: (Re-)apply the saved configuration from `/etc/sa818.conf` to the SA818 (without the menu)
+`--conf <config-file>` :  "saved" configuration file (default /etc/sa818.conf)
+
+`--apply`: (Re-)apply the "saved" configuration from `/etc/sa818.conf` to the SA818 (without the menu)
 
 `--debug`: change logging to debug level
 
@@ -23,7 +25,7 @@ sa818-menu - Configure an SA818 device using an interactive menu
 
 With no options, executing `sudo sa818-menu` will open a menu driven utility for configuring an SA818 module.
 
-The configuration will be saved in `/etc/sa818.conf`, and can be re-applied from the command line using `sudo sa818-menu --apply`.
+The configuration will be saved in `/etc/sa818.conf`, and can be re-applied from the command line using `sudo sa818-menu --apply`.  The `--conf` argument can be used to specify an alternate "saved" configuration file.
 
 The `sa818-menu` utility is a menu driven front end for the `sa818` programming utility. As such, see the [`sa818`](./sa818.md) man page for valid option ranges and defaults.
 

--- a/bin/sa818.1.md
+++ b/bin/sa818.1.md
@@ -50,7 +50,7 @@ The SA818 module cannot have its settings "read", only programmed. This utility 
 
 `--squelch 0-8`: Receiver squelch level, 0-8. Default is 4
 
-`--ctcss CTCSS[,CTCSS]`: Specify CTCSS (PL) tone. If one tone is specified, TX/RX tones will be the same. Two tones, separated by a comma will specify different tones for TX,RX. Default is 0.0 (no tone). CTCSS is mutually exclusive from DCS. See list below for valid tones 
+`--ctcss CTCSS[,CTCSS]`: Specify CTCSS (PL) tone. If one tone is specified, TX/RX tones will be the same. Two tones, separated by a comma will specify different tones for TX,RX. Default is "None" (no tone). CTCSS is mutually exclusive from DCS. See list below for valid tones 
 
 CTCSS codes (PL Tones):
 
@@ -63,13 +63,15 @@ CTCSS codes (PL Tones):
 
 DCS Codes (must be followed by N or I for Normal or Inverse):
 
-023, 025, 026, 031, 032, 036, 043, 047, 051, 053, 054, 065, 071, 072,
-073, 074, 114, 115, 116, 125, 131, 132, 134, 143, 152, 155, 156, 162,
-165, 172, 174, 205, 223, 226, 243, 244, 245, 251, 261, 263, 265, 271,
-306, 311, 315, 331, 343, 346, 351, 364, 365, 371, 411, 412, 413, 423,
-431, 432, 445, 464, 465, 466, 503, 506, 516, 532, 546, 565, 606, 612,
-624, 627, 631, 632, 654, 662, 664, 703, 712, 723, 731, 732, 734, 743,
-754
+023, 025, 026, 031, 032, 043, 047, 051, 054, 065,
+071, 072, 073, 074, 114, 115, 116, 125, 131, 132,
+134, 143, 152, 155, 156, 162, 165, 172, 174, 205,
+223, 226, 243, 244, 245, 251, 261, 263, 265, 271,
+306, 311, 315, 331, 343, 346, 351, 364, 365, 371,
+411, 412, 413, 423, 431, 432, 445, 464, 465, 466,
+503, 506, 516, 532, 546, 565, 606, 612, 624, 627,
+631, 632, 654, 662, 664, 703, 712, 723, 731, 732,
+734, 743, 754,
 
 `--tail open|close`: Specify if CTCSS revere burst is enabled (`close`) or disabled (`open`). Default is none (`open`)
 


### PR DESCRIPTION
The `sa818` command needed some changes (clarifications) about how to disable a CTCSS tone.  Specifically, do you specify a tone of "None" or "0".

The `sa818-menu` was not allowing one to configure CTCSS tones with one RX (or TX) tone enable and the other TX (or RX) tone disabled.

Lastly, the `sa818` command now has a new `--conf <config-file>` argument that allows one to use an alternate "saved" configuration file.  This might be handy for those needing to configure multiple SA818 modules.