### PR TITLE
Move DAHDI package dependencies to "asl3-asterisk"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,9 +11,9 @@ Rules-Requires-Root: binary-targets
 
 Package: asl3
 Architecture: all
-Depends: ${misc:Depends}, asl3-asterisk, asl3-menu, dahdi-linux, lsb-release, 
+Depends: ${misc:Depends}, asl3-asterisk, asl3-menu, lsb-release, 
   bind9-dnsutils, uuid, curl, lame, sox, whiptail, python3-serial,
-  python3-requests, dahdi-dkms (>= 3.4.0-6)
+  python3-requests
 Breaks: asl3-pi-appliance (<< 1.8.0)
 Suggests: allmon3, asl3-update-nodelist
 Description: AllStarLink 3


### PR DESCRIPTION
The DAHDI package dependencies should be expressed by "asl3-asterisk" since that's where `asterisk` is packaged/installed.

Depends on: https://github.com/AllStarLink/asl3-asterisk/pull/77